### PR TITLE
ControllerAdvice를 이용한 exception handler 구현

### DIFF
--- a/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
+++ b/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.selldok.toy.employee.entity.ApplyHistory;
 import com.selldok.toy.employee.model.ApplyHistoryDto;
 import com.selldok.toy.employee.service.AppliedHistoryService;
+import com.selldok.toy.exception.RestApiException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -65,13 +66,12 @@ public class ApplyHistoryController {
 	 * 
 	 * @param ApplyHistoryDto applyHistoryDto
 	 * @return
-	 * @throws Exception
+	 * @throws RestApiException
 	 */
 	@PostMapping("employees/{applicantId}/applyHistories")
 	@ResponseBody
-	public ResponseEntity<Long> create(@RequestBody ApplyHistoryDto applyHistoryDto, @PathVariable Long applicantId) throws Exception {
+	public ResponseEntity<Long> create(@RequestBody ApplyHistoryDto applyHistoryDto, @PathVariable Long applicantId) throws RestApiException {
 		applyHistoryDto.setApplicantId(applicantId);
-		log.debug("applyHistoryDto={}", applyHistoryDto);
 		return new ResponseEntity<>(applyHistoryService.create(applyHistoryDto), HttpStatus.OK);
 	}
 

--- a/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
+++ b/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
@@ -64,9 +64,9 @@ public class ApplyHistoryController {
 	/**
 	 * 지원하기
 	 * 
-	 * @param ApplyHistoryDto applyHistoryDto
+	 * @param applyHistoryDto
+	 * @param applicantId
 	 * @return
-	 * @throws RestApiException
 	 */
 	@PostMapping("employees/{applicantId}/applyHistories")
 	@ResponseBody
@@ -80,9 +80,10 @@ public class ApplyHistoryController {
 	 * 이 메소드를 쓰면 set 하지 않은 필드들은 null로 갱신되는 문제 있음
 	 * 일부 컬럼만 갱신하는 기능 필요할까?
 	 * 
-	 * @param ApplyHistoryDto updatingApplyHistoryDto
+	 * @param id
+	 * @param updatingApplyHistoryDto
+	 * @param applicantId
 	 * @return
-	 * @throws Exception
 	 */
 	@PutMapping("employees/{applicantId}/applyHistories/{id}")
 	@ResponseBody

--- a/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
+++ b/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
@@ -70,7 +70,7 @@ public class ApplyHistoryController {
 	 */
 	@PostMapping("employees/{applicantId}/applyHistories")
 	@ResponseBody
-	public ResponseEntity<Long> create(@RequestBody ApplyHistoryDto applyHistoryDto, @PathVariable Long applicantId) throws RestApiException {
+	public ResponseEntity<Long> create(@RequestBody ApplyHistoryDto applyHistoryDto, @PathVariable Long applicantId) {
 		applyHistoryDto.setApplicantId(applicantId);
 		return new ResponseEntity<>(applyHistoryService.create(applyHistoryDto), HttpStatus.OK);
 	}
@@ -86,7 +86,7 @@ public class ApplyHistoryController {
 	 */
 	@PutMapping("employees/{applicantId}/applyHistories/{id}")
 	@ResponseBody
-	public ResponseEntity update(@PathVariable Long id, @RequestBody ApplyHistoryDto updatingApplyHistoryDto, @PathVariable Long applicantId) throws Exception {
+	public ResponseEntity update(@PathVariable Long id, @RequestBody ApplyHistoryDto updatingApplyHistoryDto, @PathVariable Long applicantId) {
 		updatingApplyHistoryDto.setId(id);
 		updatingApplyHistoryDto.setApplicantId(applicantId);
 		applyHistoryService.update(updatingApplyHistoryDto);
@@ -102,7 +102,7 @@ public class ApplyHistoryController {
 	 */
 	@PutMapping("employees/{applicantId}/applyHistories/{id}/changeStatus")
 	@ResponseBody
-	public ResponseEntity changeStatus(@PathVariable Long id, @RequestBody ApplyHistoryDto updatingApplyHistoryDto, @PathVariable Long applicantId) throws Exception {
+	public ResponseEntity changeStatus(@PathVariable Long id, @RequestBody ApplyHistoryDto updatingApplyHistoryDto, @PathVariable Long applicantId) {
 		updatingApplyHistoryDto.setId(id);
 		updatingApplyHistoryDto.setApplicantId(applicantId);
 		applyHistoryService.changeStatus(updatingApplyHistoryDto);

--- a/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
+++ b/src/main/java/com/selldok/toy/employee/controller/ApplyHistoryController.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import com.selldok.toy.employee.entity.ApplyHistory;
 import com.selldok.toy.employee.model.ApplyHistoryDto;
 import com.selldok.toy.employee.service.AppliedHistoryService;
-import com.selldok.toy.exception.RestApiException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -43,7 +42,7 @@ public class ApplyHistoryController {
 	 * @throws Exception
 	 */
 	@GetMapping("company/applications")
-	public String companyApplications(Model model) throws Exception {
+	public String companyApplications(Model model){
         //model.addAttribute("employee", response);
 		return "company/applications";
 	}
@@ -56,7 +55,7 @@ public class ApplyHistoryController {
 	 * @throws Exception
 	 */
 	@GetMapping("employees/applications")
-	public String employeesApplications(Model model) throws Exception {
+	public String employeesApplications(Model model) {
         //model.addAttribute("employee", response);
 		return "employee/applications";
 	}
@@ -116,7 +115,7 @@ public class ApplyHistoryController {
 	 */
 	@GetMapping("employees/{applicantId}/applyHistories/getApplyCount")
 	@ResponseBody
-	public ResponseEntity<Map<String, Long>> groupByCountByStatusOfApplicant(@PathVariable Long applicantId) throws Exception {
+	public ResponseEntity<Map<String, Long>> groupByCountByStatusOfApplicant(@PathVariable Long applicantId) {
 		return new ResponseEntity<>(applyHistoryService.groupByCountByStatusOfApplicant(applicantId), HttpStatus.ACCEPTED);
 	}
 
@@ -126,7 +125,7 @@ public class ApplyHistoryController {
 	 */
 	@GetMapping("company/{companyId}/applyHistories/getApplyCount")
 	@ResponseBody
-	public ResponseEntity<Map<String, Long>> groupByCountByStatusOfCompany(@PathVariable Long companyId) throws Exception {
+	public ResponseEntity<Map<String, Long>> groupByCountByStatusOfCompany(@PathVariable Long companyId) {
 		return new ResponseEntity<>(applyHistoryService.groupByCountByStatusOfCompany(companyId), HttpStatus.ACCEPTED);
 	}
 
@@ -146,7 +145,7 @@ public class ApplyHistoryController {
 		,@RequestParam(required=false) String companyName
 		,@RequestParam(required=false) ApplyHistory.Status status
 		,Pageable pageable
-	) throws Exception {
+	) {
 		ApplyHistoryDto applyHistoryDto = new ApplyHistoryDto(); 
 		applyHistoryDto.setApplicantId(applicantId);
 		applyHistoryDto.setName(name);
@@ -171,7 +170,7 @@ public class ApplyHistoryController {
 		,@RequestParam(required=false) String companyName
 		,@RequestParam(required=false) ApplyHistory.Status status
 		,Pageable pageable
-	) throws Exception {
+	) {
 		ApplyHistoryDto applyHistoryDto = new ApplyHistoryDto(); 
 		applyHistoryDto.setCompanyId(companyId);
 		applyHistoryDto.setName(name);

--- a/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
+++ b/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
@@ -69,7 +69,7 @@ public class AppliedHistoryService {
 			applyHistoryRepository.save(applyHistory);
 			newApplyHistoryId = applyHistory.getId();
 		} else {
-			throw new RestApiException(new ApiErrorMsg("지원자 정보 혹은 회사 정보가 없습니다", "ERR001", HttpStatus.NOT_FOUND), new RuntimeException());
+			throw new RestApiException(new ApiErrorMsg("지원자 정보 혹은 회사 정보가 없습니다", "ERR001", HttpStatus.NOT_FOUND));
 		}
 		log.debug("newApplyHistoryId={}", newApplyHistoryId);
 
@@ -88,7 +88,7 @@ public class AppliedHistoryService {
 		if(updatingApplyHistoryDto.getApplicantId() != null) {
 			applicant = employeeRepository.findById(updatingApplyHistoryDto.getApplicantId());
 			if(applicant.isEmpty()) {
-				throw new RestApiException(new ApiErrorMsg("존재하지 않는 구직자입니다", "ERR002", HttpStatus.NOT_FOUND), new RuntimeException());
+				throw new RestApiException(new ApiErrorMsg("존재하지 않는 구직자입니다", "ERR002", HttpStatus.NOT_FOUND));
 			}
 		}
 
@@ -96,7 +96,7 @@ public class AppliedHistoryService {
 		if(updatingApplyHistoryDto.getEmploymentBoardId() != null) {
 			employmentBoard = boardRepository.findById(updatingApplyHistoryDto.getEmploymentBoardId());
 			if(employmentBoard.isEmpty()) {
-				throw new RestApiException(new ApiErrorMsg("존재하지 않는 채용공고입니다", "ERR003", HttpStatus.NOT_FOUND), new RuntimeException());
+				throw new RestApiException(new ApiErrorMsg("존재하지 않는 채용공고입니다", "ERR003", HttpStatus.NOT_FOUND));
 			}
 		}
 
@@ -118,7 +118,7 @@ public class AppliedHistoryService {
 			updatingApplyHistory.setBasicInfo(updatingBasicInfoBuilder.build());
 			applyHistoryRepository.save(updatingApplyHistory);			
 		} else {
-			throw new RestApiException(new ApiErrorMsg("존재하지 않는 지원이력입니다", "ERR004", HttpStatus.NOT_FOUND), new RuntimeException());
+			throw new RestApiException(new ApiErrorMsg("존재하지 않는 지원이력입니다", "ERR004", HttpStatus.NOT_FOUND));
 		}
 	}
 

--- a/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
+++ b/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
@@ -48,7 +48,7 @@ public class AppliedHistoryService {
 	 * @return
 	 * @throws RestApiException
 	 */
-	public Long create(ApplyHistoryDto newApplyHistoryDto) throws RestApiException {
+	public Long create(ApplyHistoryDto newApplyHistoryDto) {
 		log.debug("newApplyHistoryDto={}", newApplyHistoryDto);
 		Long newApplyHistoryId = null;
 		Optional<Employee> applicant = employeeRepository.findById(newApplyHistoryDto.getApplicantId());
@@ -83,7 +83,7 @@ public class AppliedHistoryService {
 	 * @param updatingApplyHistoryDto
 	 * @throws RestApiException
 	 */
-	public void update(ApplyHistoryDto updatingApplyHistoryDto) throws RestApiException {
+	public void update(ApplyHistoryDto updatingApplyHistoryDto) {
 		log.debug("updatingApplyHistoryDto={}", updatingApplyHistoryDto);
 		Optional<ApplyHistory> existingApplyHistory = applyHistoryRepository.findById(updatingApplyHistoryDto.getId());
 		Optional<Employee> applicant = null;

--- a/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
+++ b/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
@@ -14,9 +14,12 @@ import com.selldok.toy.employee.entity.BasicInfo;
 import com.selldok.toy.employee.entity.BasicInfo.BasicInfoBuilder;
 import com.selldok.toy.employee.entity.Employee;
 import com.selldok.toy.employee.model.ApplyHistoryDto;
+import com.selldok.toy.exception.ApiErrorMsg;
+import com.selldok.toy.exception.RestApiException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -40,8 +43,12 @@ public class AppliedHistoryService {
 
 	/**
 	 * 신규 생성
+	 * 
+	 * @param newApplyHistoryDto
+	 * @return
+	 * @throws RestApiException
 	 */
-	public Long create(ApplyHistoryDto newApplyHistoryDto) throws Exception {
+	public Long create(ApplyHistoryDto newApplyHistoryDto) throws RestApiException {
 		log.debug("newApplyHistoryDto={}", newApplyHistoryDto);
 		Long newApplyHistoryId = null;
 		Optional<Employee> applicant = employeeRepository.findById(newApplyHistoryDto.getApplicantId());
@@ -63,7 +70,7 @@ public class AppliedHistoryService {
 			applyHistoryRepository.save(applyHistory);
 			newApplyHistoryId = applyHistory.getId();
 		} else {
-			throw new Exception("지원자 정보 혹은 회사 정보가 없습니다");
+			throw new RestApiException(new ApiErrorMsg("지원자 정보 혹은 회사 정보가 없습니다", "ERR001", HttpStatus.NOT_FOUND), new RuntimeException());
 		}
 		log.debug("newApplyHistoryId={}", newApplyHistoryId);
 
@@ -72,15 +79,18 @@ public class AppliedHistoryService {
 
 	/**
 	 * 갱신
+	 * 
+	 * @param updatingApplyHistoryDto
+	 * @throws RestApiException
 	 */
-	public void update(ApplyHistoryDto updatingApplyHistoryDto) throws Exception {
+	public void update(ApplyHistoryDto updatingApplyHistoryDto) throws RestApiException {
 		log.debug("updatingApplyHistoryDto={}", updatingApplyHistoryDto);
 		Optional<ApplyHistory> existingApplyHistory = applyHistoryRepository.findById(updatingApplyHistoryDto.getId());
 		Optional<Employee> applicant = null;
 		if(updatingApplyHistoryDto.getApplicantId() != null) {
 			applicant = employeeRepository.findById(updatingApplyHistoryDto.getApplicantId());
 			if(applicant.isEmpty()) {
-				throw new Exception("존재하지 않는 구직자입니다");
+				throw new RestApiException(new ApiErrorMsg("존재하지 않는 구직자입니다", "ERR002", HttpStatus.NOT_FOUND), new RuntimeException());
 			}
 		}
 
@@ -88,7 +98,7 @@ public class AppliedHistoryService {
 		if(updatingApplyHistoryDto.getEmploymentBoardId() != null) {
 			employmentBoard = boardRepository.findById(updatingApplyHistoryDto.getEmploymentBoardId());
 			if(employmentBoard.isEmpty()) {
-				throw new Exception("존재하지 않는 채용공고입니다");
+				throw new RestApiException(new ApiErrorMsg("존재하지 않는 채용공고입니다", "ERR003", HttpStatus.NOT_FOUND), new RuntimeException());
 			}
 		}
 
@@ -110,7 +120,7 @@ public class AppliedHistoryService {
 			updatingApplyHistory.setBasicInfo(updatingBasicInfoBuilder.build());
 			applyHistoryRepository.save(updatingApplyHistory);			
 		} else {
-			throw new Exception("존재하지 않는 지원이력입니다");
+			throw new RestApiException(new ApiErrorMsg("존재하지 않는 지원이력입니다", "ERR004", HttpStatus.NOT_FOUND), new RuntimeException());
 		}
 	}
 

--- a/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
+++ b/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
@@ -14,7 +14,7 @@ import com.selldok.toy.employee.entity.BasicInfo;
 import com.selldok.toy.employee.entity.BasicInfo.BasicInfoBuilder;
 import com.selldok.toy.employee.entity.Employee;
 import com.selldok.toy.employee.model.ApplyHistoryDto;
-import com.selldok.toy.exception.ApiErrorMsg;
+import com.selldok.toy.exception.ApplyErrorCode;
 import com.selldok.toy.exception.RestApiException;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,8 +52,12 @@ public class AppliedHistoryService {
 		Long newApplyHistoryId = null;
 		Optional<Employee> applicant = employeeRepository.findById(newApplyHistoryDto.getApplicantId());
 		Optional<Board> employmentBoard = boardRepository.findById(newApplyHistoryDto.getEmploymentBoardId());
-		if(applicant.isPresent()
-			&& employmentBoard.isPresent()) {
+
+		if(applicant.isEmpty()) {
+			throw new RestApiException(ApplyErrorCode.APY_001);
+		} else if(employmentBoard.isEmpty()) {
+			throw new RestApiException(ApplyErrorCode.APY_002);
+		} else {
 			BasicInfo memberBasicInfo = BasicInfo.builder()
 			.name(newApplyHistoryDto.getName())
 			.email(newApplyHistoryDto.getEmail())
@@ -68,8 +72,6 @@ public class AppliedHistoryService {
 			.build();
 			applyHistoryRepository.save(applyHistory);
 			newApplyHistoryId = applyHistory.getId();
-		} else {
-			throw new RestApiException(new ApiErrorMsg("지원자 정보 혹은 회사 정보가 없습니다", "ERR001", HttpStatus.NOT_FOUND));
 		}
 		log.debug("newApplyHistoryId={}", newApplyHistoryId);
 
@@ -88,7 +90,7 @@ public class AppliedHistoryService {
 		if(updatingApplyHistoryDto.getApplicantId() != null) {
 			applicant = employeeRepository.findById(updatingApplyHistoryDto.getApplicantId());
 			if(applicant.isEmpty()) {
-				throw new RestApiException(new ApiErrorMsg("존재하지 않는 구직자입니다", "ERR002", HttpStatus.NOT_FOUND));
+				throw new RestApiException(ApplyErrorCode.APY_001, HttpStatus.NOT_FOUND);
 			}
 		}
 
@@ -96,7 +98,7 @@ public class AppliedHistoryService {
 		if(updatingApplyHistoryDto.getEmploymentBoardId() != null) {
 			employmentBoard = boardRepository.findById(updatingApplyHistoryDto.getEmploymentBoardId());
 			if(employmentBoard.isEmpty()) {
-				throw new RestApiException(new ApiErrorMsg("존재하지 않는 채용공고입니다", "ERR003", HttpStatus.NOT_FOUND));
+				throw new RestApiException(ApplyErrorCode.APY_002, HttpStatus.NOT_FOUND);
 			}
 		}
 
@@ -118,7 +120,7 @@ public class AppliedHistoryService {
 			updatingApplyHistory.setBasicInfo(updatingBasicInfoBuilder.build());
 			applyHistoryRepository.save(updatingApplyHistory);			
 		} else {
-			throw new RestApiException(new ApiErrorMsg("존재하지 않는 지원이력입니다", "ERR004", HttpStatus.NOT_FOUND));
+			throw new RestApiException(ApplyErrorCode.APY_003, HttpStatus.NOT_FOUND);
 		}
 	}
 

--- a/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
+++ b/src/main/java/com/selldok/toy/employee/service/AppliedHistoryService.java
@@ -46,7 +46,6 @@ public class AppliedHistoryService {
 	 * 
 	 * @param newApplyHistoryDto
 	 * @return
-	 * @throws RestApiException
 	 */
 	public Long create(ApplyHistoryDto newApplyHistoryDto) {
 		log.debug("newApplyHistoryDto={}", newApplyHistoryDto);
@@ -81,7 +80,6 @@ public class AppliedHistoryService {
 	 * 갱신
 	 * 
 	 * @param updatingApplyHistoryDto
-	 * @throws RestApiException
 	 */
 	public void update(ApplyHistoryDto updatingApplyHistoryDto) {
 		log.debug("updatingApplyHistoryDto={}", updatingApplyHistoryDto);

--- a/src/main/java/com/selldok/toy/exception/ApiErrorMsg.java
+++ b/src/main/java/com/selldok/toy/exception/ApiErrorMsg.java
@@ -4,6 +4,8 @@ import org.springframework.http.HttpStatus;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -12,17 +14,20 @@ import lombok.ToString;
  */
 @Getter
 @Setter
+@RequiredArgsConstructor
 @AllArgsConstructor
 @ToString
 public class ApiErrorMsg {
 	/**
 	 * 사용자 정의 에러메시지
 	 */	
+	@NonNull
 	private String message;
 
 	/**
 	 * 사용자 정의 에러코드
 	 */	
+	@NonNull
 	private String errorCode;
 
 	/**

--- a/src/main/java/com/selldok/toy/exception/ApiErrorMsg.java
+++ b/src/main/java/com/selldok/toy/exception/ApiErrorMsg.java
@@ -1,0 +1,32 @@
+package com.selldok.toy.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * api 오류 메시지
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@ToString
+public class ApiErrorMsg {
+	/**
+	 * 사용자 정의 에러메시지
+	 */	
+	private String message;
+
+	/**
+	 * 사용자 정의 에러코드
+	 */	
+	private String errorCode;
+
+	/**
+	 * Http 상태코드. 기본 상태 코드는 INTERNAL_SERVER_ERROR. 필요시 해당 상태코드로 변경
+	 */
+	private HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+}

--- a/src/main/java/com/selldok/toy/exception/ApplyErrorCode.java
+++ b/src/main/java/com/selldok/toy/exception/ApplyErrorCode.java
@@ -1,0 +1,27 @@
+package com.selldok.toy.exception;
+
+import com.selldok.toy.exception.RestApiException.ApiErrorCode;
+
+/**
+ * 지원하기 api 전용 에러코드
+ */
+public enum ApplyErrorCode implements ApiErrorCode {
+	/** 지원자 정보가 없습니다. */
+	APY_001("지원자 정보가 없습니다.")
+	/** 구인 정보가 없습니다. */
+	,APY_002("구인 정보가 없습니다.")
+	/** 지원한 이력이 없습니다. */
+	,APY_003("지원한 이력이 없습니다.")
+	;
+
+	String errorMessage;
+
+	ApplyErrorCode(String errorMessage) {
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public String geErrorMessage() {
+		return errorMessage;
+	}
+}

--- a/src/main/java/com/selldok/toy/exception/CommonErrorCode.java
+++ b/src/main/java/com/selldok/toy/exception/CommonErrorCode.java
@@ -6,8 +6,8 @@ import com.selldok.toy.exception.RestApiException.ApiErrorCode;
  * 공통 api 에러 코드는 여기에 추가해 주세요
  */
 public enum CommonErrorCode implements ApiErrorCode {
-    /** 정의되지 않은 오류가 발생하였습니다. */
-    CMM_001("정의되지 않은 오류가 발생하였습니다.");
+	/** 정의되지 않은 오류가 발생하였습니다. */
+	CMM_001("정의되지 않은 오류가 발생하였습니다.");
 
 	private String errorMessage;
 

--- a/src/main/java/com/selldok/toy/exception/CommonErrorCode.java
+++ b/src/main/java/com/selldok/toy/exception/CommonErrorCode.java
@@ -1,0 +1,22 @@
+package com.selldok.toy.exception;
+
+import com.selldok.toy.exception.RestApiException.ApiErrorCode;
+
+/**
+ * 공통 api 에러 코드는 여기에 추가해 주세요
+ */
+public enum CommonErrorCode implements ApiErrorCode {
+    /** 정의되지 않은 오류가 발생하였습니다. */
+    CMM_001("정의되지 않은 오류가 발생하였습니다.");
+
+	private String errorMessage;
+
+	CommonErrorCode(String errorMessage) {
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public String geErrorMessage() {
+		return errorMessage;
+	}
+}

--- a/src/main/java/com/selldok/toy/exception/RestApiException.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiException.java
@@ -1,0 +1,21 @@
+package com.selldok.toy.exception;
+
+/**
+ * RestApi 호출 시 Exception
+ */
+@SuppressWarnings("serial")
+public class RestApiException extends RuntimeException {
+	/**
+	 * api 오류 메시지
+	 */
+	final transient ApiErrorMsg apiErrorMsg;
+
+	public RestApiException(ApiErrorMsg apiErrorMsg, Throwable err) {
+		super(err);
+		this.apiErrorMsg = apiErrorMsg;
+	}
+
+	public ApiErrorMsg getApiErrorMsg() {
+		return this.apiErrorMsg;
+	}
+}

--- a/src/main/java/com/selldok/toy/exception/RestApiException.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiException.java
@@ -1,37 +1,59 @@
 package com.selldok.toy.exception;
 
+import org.springframework.http.HttpStatus;
+
 /**
  * RestApi 호출 시 Exception
  */
-@SuppressWarnings("serial")
 public class RestApiException extends RuntimeException {
+	private static final long serialVersionUID = -5978279099559304240L;
+
+	/**
+	 * 모든 api 에러코드의 인터페이스
+	 */
+	public interface ApiErrorCode {
+		String geErrorMessage();
+	}
+
 	/**
 	 * api 오류 메시지
 	 */
-	final transient ApiErrorMsg apiErrorMsg;
+	private final transient ApiErrorMsg apiErrorMsg;
 
 	/**
-	 * ApiErrorMsg만 받는 생성자 
+	 * ApiErrorCode만 받는 생성자 
 	 * 
-	 * @param apiErrorMsg
+	 * @param ApiErrorCode errorCode ApiErrorCode를 implement하여 업무별로 만들어주세요
 	 */
-	public RestApiException(ApiErrorMsg apiErrorMsg) {
-		super(apiErrorMsg.getMessage());
-		this.apiErrorMsg = apiErrorMsg;
+	public RestApiException(ApiErrorCode errorCode) {
+		super(errorCode.geErrorMessage());
+		this.apiErrorMsg = new ApiErrorMsg(errorCode.geErrorMessage(), errorCode.toString());
+	}
+
+	/**
+	 * ApiErrorMsg와 HttpStatus를 받는 생성자 
+	 * 
+	 * @param ApiErrorCode errorCode ApiErrorCode를 implement하여 업무별로 만들어주세요
+	 * @param HttpStatus httpStatus
+	 */
+	public RestApiException(ApiErrorCode errorCode, HttpStatus httpStatus) {
+		super(errorCode.geErrorMessage());
+		this.apiErrorMsg = new ApiErrorMsg(errorCode.geErrorMessage(), errorCode.toString(), httpStatus);
 	}	
 
 	/**
-	 * ApiErrorMsg과 Throwable를 받는 생성자 
+	 * ApiErrorMsg와 HttpStatus, Throwable을 받는 생성자 
 	 * 
-	 * @param apiErrorMsg
+	 * @param ApiErrorCode errorCode ApiErrorCode를 implement하여 업무별로 만들어주세요
+	 * @param HttpStatus httpStatus
 	 * @param Throwable cause 오류를 발생시킨 원인 Throwable을 넘겨준다.
 	 */
-	public RestApiException(ApiErrorMsg apiErrorMsg, Throwable cause) {
-		super(apiErrorMsg.getMessage(), cause);
-		this.apiErrorMsg = apiErrorMsg;
+	public RestApiException(ApiErrorCode errorCode, HttpStatus httpStatus, Throwable cause) {
+		super(errorCode.geErrorMessage(), cause);
+		this.apiErrorMsg = new ApiErrorMsg(errorCode.geErrorMessage(), errorCode.toString(), httpStatus);
 	}
 
 	public ApiErrorMsg getApiErrorMsg() {
-		return this.apiErrorMsg;
+		return apiErrorMsg;
 	}
 }

--- a/src/main/java/com/selldok/toy/exception/RestApiException.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiException.java
@@ -10,8 +10,24 @@ public class RestApiException extends RuntimeException {
 	 */
 	final transient ApiErrorMsg apiErrorMsg;
 
-	public RestApiException(ApiErrorMsg apiErrorMsg, Throwable err) {
-		super(err);
+	/**
+	 * ApiErrorMsg만 받는 생성자 
+	 * 
+	 * @param apiErrorMsg
+	 */
+	public RestApiException(ApiErrorMsg apiErrorMsg) {
+		super(apiErrorMsg.getMessage());
+		this.apiErrorMsg = apiErrorMsg;
+	}	
+
+	/**
+	 * ApiErrorMsg과 Throwable를 받는 생성자 
+	 * 
+	 * @param apiErrorMsg
+	 * @param Throwable cause 오류를 발생시킨 원인 Throwable을 넘겨준다.
+	 */
+	public RestApiException(ApiErrorMsg apiErrorMsg, Throwable cause) {
+		super(apiErrorMsg.getMessage(), cause);
 		this.apiErrorMsg = apiErrorMsg;
 	}
 

--- a/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
@@ -21,32 +21,34 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class RestApiExceptionHandler {
 	/**
-	 * 처리할 Exception.class 지정
+	 * 처리할 Exception 지정
 	 * @param ex
 	 * @return
 	 */
 	@ExceptionHandler(RestApiException.class)
-	public ResponseEntity<ApiErrorMsg> handleException(RestApiException ex)
+	public ResponseEntity<ApiErrorMsg> handleRestApiException(RestApiException ex)
 	{
 		log.error("handleException in {} ex.getApiErrorMsg()={}", this.getClass().getSimpleName(), ex.getApiErrorMsg());
 		return new ResponseEntity<>(ex.getApiErrorMsg(), ex.getApiErrorMsg().getStatus());
 	}
 
 	/**
-	 * 데모용 
-	 * 정상 처리 테스트 : ~/throwExceptionDemo?throwException=true
-	 * 오류 발생 테스트 : ~/throwExceptionDemo?throwException=false
+	 * 데모용 정상 처리 테스트 : ~/throwExceptionDemo?throwException=true 오류 발생 테스트 :
+	 * ~/throwExceptionDemo?throwException=false
 	 * 
-	 * <ApiErrorMsg 샘플>
-	 * ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지");
-	 * ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지", "ERR001(해당 시스템에서 정의한 오류 코드)");
+	 * <ApiErrorMsg 샘플> ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류
+	 * 메시지"); ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지",
+	 * "ERR001(해당 시스템에서 정의한 오류 코드)");
+	 * 
+	 * @param throwException
+	 * @return
 	 */
 	@GetMapping(value = "/throwExceptionDemo")
-	public Map<String, Object> throwExceptionTest(@RequestParam(required = false) Boolean throwException) {		
+	public Map<String, Object> throwExceptionTest(@RequestParam(required = false) Boolean throwException) {
 		log.error("throwException={}", throwException);
 
 		Map<String, Object> rtn = null;
-		if(throwException == null || !throwException) {
+		if(throwException != null && throwException) {
 			throw new RestApiException(new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지", "ERR001(해당 시스템에서 정의한 오류 코드)", HttpStatus.INTERNAL_SERVER_ERROR), new RuntimeException());
 		} else {
 			rtn = new HashMap<>();

--- a/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
@@ -1,0 +1,58 @@
+package com.selldok.toy.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 모든 컨트롤러에서 RestApiException 발생시 처리할 핸들러
+ */
+@Slf4j
+@RestController
+@RestControllerAdvice
+public class RestApiExceptionHandler {
+	/**
+	 * 처리할 Exception.class 지정
+	 * @param ex
+	 * @return
+	 */
+	@ExceptionHandler(RestApiException.class)
+	public ResponseEntity<ApiErrorMsg> handleException(RestApiException ex)
+	{
+		log.error("handleException in {} ex.getApiErrorMsg()={}", this.getClass().getSimpleName(), ex.getApiErrorMsg());
+		return new ResponseEntity<>(ex.getApiErrorMsg(), ex.getApiErrorMsg().getStatus());
+	}
+
+	/**
+	 * 데모용 
+	 * 정상 처리 테스트 : ~/throwExceptionDemo?throwException=true
+	 * 오류 발생 테스트 : ~/throwExceptionDemo?throwException=false
+	 * 
+	 * <ApiErrorMsg 샘플>
+	 * ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지");
+	 * ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지", "ERR001(해당 시스템에서 정의한 오류 코드)");
+	 */
+	@GetMapping(value = "/throwExceptionDemo")
+	public Map<String, Object> throwExceptionTest(@RequestParam(required = false) Boolean throwException) {		
+		log.error("throwException={}", throwException);
+
+		Map<String, Object> rtn = null;
+		if(throwException == null || !throwException) {
+			throw new RestApiException(new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지", "ERR001(해당 시스템에서 정의한 오류 코드)", HttpStatus.INTERNAL_SERVER_ERROR), new RuntimeException());
+		} else {
+			rtn = new HashMap<>();
+			rtn.put("successMsg", "정상 처리된 경우");
+		}
+		
+		return rtn;
+	}	
+}

--- a/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
@@ -40,7 +40,7 @@ public class RestApiExceptionHandler {
 	public ResponseEntity<ApiErrorMsg> handleException(Exception ex)
 	{
 		log.error("handleException in {}", this.getClass().getSimpleName(), ex);
-		ApiErrorMsg apiErrorMsg = new ApiErrorMsg("정의되지 않은 오류가 발생하였습니다.", "N/A", HttpStatus.INTERNAL_SERVER_ERROR);
+		ApiErrorMsg apiErrorMsg = new ApiErrorMsg(CommonErrorCode.CMM_001.geErrorMessage(), CommonErrorCode.CMM_001.name(), HttpStatus.INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(apiErrorMsg, apiErrorMsg.getStatus());
 	}	
 }

--- a/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
@@ -3,6 +3,8 @@ package com.selldok.toy.exception;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,20 +23,39 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class RestApiExceptionHandler {
 	/**
-	 * 처리할 Exception 지정
-	 * @param ex
+	 * RestApiException 처리
+	 * @param RestApiException ex
 	 * @return
 	 */
 	@ExceptionHandler(RestApiException.class)
+	@Order(Ordered.HIGHEST_PRECEDENCE)
 	public ResponseEntity<ApiErrorMsg> handleRestApiException(RestApiException ex)
 	{
-		log.error("handleException in {} ex.getApiErrorMsg()={}", this.getClass().getSimpleName(), ex.getApiErrorMsg());
+		log.error("handleException in {} ex.getApiErrorMsg()={}", this.getClass().getSimpleName(), ex.getApiErrorMsg(), ex);
 		return new ResponseEntity<>(ex.getApiErrorMsg(), ex.getApiErrorMsg().getStatus());
 	}
 
 	/**
-	 * 데모용 정상 처리 테스트 : ~/throwExceptionDemo?throwException=true 오류 발생 테스트 :
-	 * ~/throwExceptionDemo?throwException=false
+	 * Exception 처리
+	 * 다른 핸들러가 추가될 수 있으므로 이 메소드는 LOWEST_PRECEDENCE로 지정함
+	 * 
+	 * @param Exception ex
+	 * @return
+	 */
+	@ExceptionHandler(Exception.class)
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	public ResponseEntity<ApiErrorMsg> handleException(Exception ex)
+	{
+		log.error("handleException in {}", this.getClass().getSimpleName(), ex);
+		ApiErrorMsg apiErrorMsg = new ApiErrorMsg("정의되지 않은 오류가 발생하였습니다.", "N/A", HttpStatus.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(apiErrorMsg, apiErrorMsg.getStatus());
+	}	
+
+	/**
+	 * 데모용 
+	 * 
+	 * 정상 처리 테스트 : ~/throwExceptionDemo?throwException=true 
+	 * 오류 발생 테스트 : ~/throwExceptionDemo?throwException=false
 	 * 
 	 * <ApiErrorMsg 샘플> ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류
 	 * 메시지"); ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지",

--- a/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/selldok/toy/exception/RestApiExceptionHandler.java
@@ -1,16 +1,10 @@
 package com.selldok.toy.exception;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
  * 모든 컨트롤러에서 RestApiException 발생시 처리할 핸들러
  */
 @Slf4j
-@RestController
 @RestControllerAdvice
 public class RestApiExceptionHandler {
 	/**
@@ -49,33 +42,5 @@ public class RestApiExceptionHandler {
 		log.error("handleException in {}", this.getClass().getSimpleName(), ex);
 		ApiErrorMsg apiErrorMsg = new ApiErrorMsg("정의되지 않은 오류가 발생하였습니다.", "N/A", HttpStatus.INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(apiErrorMsg, apiErrorMsg.getStatus());
-	}	
-
-	/**
-	 * 데모용 
-	 * 
-	 * 정상 처리 테스트 : ~/throwExceptionDemo?throwException=true 
-	 * 오류 발생 테스트 : ~/throwExceptionDemo?throwException=false
-	 * 
-	 * <ApiErrorMsg 샘플> ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류
-	 * 메시지"); ApiErrorMsg apiErrorMsg = new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지",
-	 * "ERR001(해당 시스템에서 정의한 오류 코드)");
-	 * 
-	 * @param throwException
-	 * @return
-	 */
-	@GetMapping(value = "/throwExceptionDemo")
-	public Map<String, Object> throwExceptionTest(@RequestParam(required = false) Boolean throwException) {
-		log.error("throwException={}", throwException);
-
-		Map<String, Object> rtn = null;
-		if(throwException != null && throwException) {
-			throw new RestApiException(new ApiErrorMsg("호출자에게 알려줄 상세한 오류 메시지", "ERR001(해당 시스템에서 정의한 오류 코드)", HttpStatus.INTERNAL_SERVER_ERROR), new RuntimeException());
-		} else {
-			rtn = new HashMap<>();
-			rtn.put("successMsg", "정상 처리된 경우");
-		}
-		
-		return rtn;
 	}	
 }

--- a/src/test/http/appliedCompany.http
+++ b/src/test/http/appliedCompany.http
@@ -8,7 +8,18 @@ Content-Type: application/json
   "phoneNumber" : "010-1111-2222",  
   "status": "APPLCN_COMPT",
   "employmentBoardId": 4
-  }
+}
+
+### 입사지원 하기 오류 발생
+POST http://localhost:9090/employees/999/applyHistories
+Content-Type: application/json
+
+{
+  "name" : "지원자명",
+  "email" : "applicant@naver.com",
+  "phoneNumber" : "010-1111-2222",  
+  "status": "APPLCN_COMPT",
+  "employmentBoardId": 4
 }
 
 ### 입사지원 수정하기

--- a/src/test/http/appliedCompany.http
+++ b/src/test/http/appliedCompany.http
@@ -10,7 +10,7 @@ Content-Type: application/json
   "employmentBoardId": 4
 }
 
-### 입사지원 하기 오류 발생
+### 입사지원 오류 발생
 POST http://localhost:9090/employees/999/applyHistories
 Content-Type: application/json
 

--- a/src/test/http/appliedCompany.http
+++ b/src/test/http/appliedCompany.http
@@ -11,7 +11,7 @@ Content-Type: application/json
 }
 
 ### 입사지원 오류 발생
-POST http://localhost:9090/employees/999/applyHistories
+POST http://localhost:9090/employees/1/applyHistories
 Content-Type: application/json
 
 {
@@ -19,7 +19,7 @@ Content-Type: application/json
   "email" : "applicant@naver.com",
   "phoneNumber" : "010-1111-2222",  
   "status": "APPLCN_COMPT",
-  "employmentBoardId": 4
+  "employmentBoardId": 4111
 }
 
 ### 입사지원 수정하기
@@ -31,7 +31,7 @@ Content-Type: application/json
   "email" : "이메일 변경@naver.com",
   "phoneNumber" : "전번변경010-1111-2222",
   "status": "APPLCN_COMPT",
-  "employmentBoardId": 4
+  "employmentBoardId": 41111
   }
 }
 

--- a/test/karate-0.9.6/employee.feature
+++ b/test/karate-0.9.6/employee.feature
@@ -31,7 +31,6 @@ Scenario: 입사 지원
 	And request 
 	"""
 		{
-
 			"employmentBoardId": 999
 		}
 	"""		

--- a/test/karate-0.9.6/employee.feature
+++ b/test/karate-0.9.6/employee.feature
@@ -38,3 +38,14 @@ Scenario: 입사 지원
 	When method post
 	Then status 404
 	And assert response.errorCode == 'ERR001'
+
+	# 지원 수정 하기에서 오류 발생시키기 위해 일부러 없는 구직자 식별자(999)를 넣음
+	Given path '/employees/999/applyHistories/1'
+	And header Content-Type = 'application/json; charset=utf-8'
+	And request 
+	"""
+		{}
+	"""		
+	When method put
+	Then status 404
+	And assert response.errorCode == 'ERR002'

--- a/test/karate-0.9.6/employee.feature
+++ b/test/karate-0.9.6/employee.feature
@@ -15,10 +15,26 @@ Scenario: 구직자 crud
 	And request 
 	"""
 		{
-		  "name" : "#(name)"
-		  ,"email" : "#(email)"
-		  ,"phoneNumber" : "#(phoneNumber)"
+			"name" : "#(name)"
+			,"email" : "#(email)"
+			,"phoneNumber" : "#(phoneNumber)"
 		}
 	"""		
 	When method post
 	Then status 202
+
+Scenario: 입사 지원
+
+	# 지원하기에서 오류 발생시키기 위해 일부러 없는 구인광고 식별자(999)를 넣음
+	Given path '/employees/1/applyHistories'
+	And header Content-Type = 'application/json; charset=utf-8'
+	And request 
+	"""
+		{
+
+			"employmentBoardId": 999
+		}
+	"""		
+	When method post
+	Then status 404
+	And assert response.errorCode == 'ERR001'


### PR DESCRIPTION
RestApiExceptionHandler와 커스텀 익셉션 객체 RestApiException를 만들었습니다. 
컨트롤러 단에서 이 익셉션이 발생하면 핸들러에서 처리할 수 있도록 하였습니다.

핸들러는 RestApiException의 속성 중 ApiErrorMsg를 반환하도록 했습니다.
아래와 같은 데이터가 반환됩니다.
```
{
  "message": "지원자 정보 혹은 회사 정보가 없습니다",
  "errorCode": "ERR001",
  "status": "NOT_FOUND"
}
```
ApiErrorMsg에는 메시지 문구와 함께 에러코드 속성을 넣었는데 에러코드가 있으면 클라이언트 측에서 기계적인 처리가 깔끔해질 수 있습니다.
Karate 테스트 파일 employee.feature의 '입사 지원' 시나리오에 errorCode를 비교해서 assert 하는 데모를 넣었습니다.

그리고 Exception.java 혹은 그 자식 클래스 익셉션이 발생할 때도 처리하도록 했습니다. 
이 경우 아래와 같은 응답이 반환되게 하였습니다.
```
{
  "message": "지정되지 않은 오류가 발생하였습니다.",
  "errorCode": "N/A",
  "status": "INTERNAL_SERVER_ERROR"
}
```
보시는 것처럼 익셉션 내용이 클라이언트측에서 보이지 않기 때문에 개발하기에 불편할 수도 있습니다. 의견 주시면 삭제하도록 하겠습니다.

MethodArgumentNotValidException.class 에 대한 핸들러는
기성님이 작업하신 ApiControllerAdvice.java가 이미 있어서 따로 만들지는 않았습니다.